### PR TITLE
Remove reset from connection

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -20,6 +20,3 @@ class Connection
 
   send: (msg) ->
     @channel.push('file_system_event', data: msg)
-
-  reset: ->
-    delete @channel

--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -22,5 +22,4 @@ class Connection
     @channel.push('file_system_event', data: msg)
 
   reset: ->
-    @channel.reset()
-
+    delete @channel

--- a/src/nsync-fs.coffee
+++ b/src/nsync-fs.coffee
@@ -59,9 +59,6 @@ class Nsync
     @isConnected = true
     @emitter.emit('did-connect')
 
-  resetConnection: ->
-    @connection.reset()
-
   loading: ->
     @emitter.emit('will-load')
 


### PR DESCRIPTION
delete channel from connection state when nsync is reset (for phoenix socket compatibility).

Nsync will have `configure` called again from within `learn-ide-tree` when the `learn-ide:did-join-channel` event is emitted on the connection reset.

@drewprice does this seem ok to call `configure` a second time and not change the logic in the `learn-ide:did-join-channel` handler on the second call?